### PR TITLE
🐛 fix(core): segv fixed

### DIFF
--- a/core/kqueue_event_unix.cpp
+++ b/core/kqueue_event_unix.cpp
@@ -7,6 +7,7 @@ int	add_read_event(const int kq, const int socket_fd)
 {
 	struct kevent	changelist;
 
+	memset(&changelist, 0, sizeof(changelist));
 	EV_SET(&changelist, socket_fd, EVFILT_READ, EV_ADD, 0, 0, 0);
 	if (kevent(kq, &changelist, 1, NULL, 0, NULL) == -1)
 		return sys_err("kevent client_fd failed");
@@ -22,6 +23,7 @@ int	set_write_ready(const int kq, Client& client)
 {
 	struct kevent	changelist;
 
+	memset(&changelist, 0, sizeof(changelist));
 	EV_SET(&changelist, client.getFd(), EVFILT_WRITE,
 			EV_ADD | EV_ONESHOT, 0, 0, 0);
 	if (kevent(kq, &changelist, 1, NULL, 0, NULL) == -1)

--- a/core/server_io_unix.cpp
+++ b/core/server_io_unix.cpp
@@ -25,6 +25,8 @@ int	send_response(const int kq, const struct kevent& event, Client& client)
 	ssize_t	len;
 
 	//event->data contains space remaining in the write buffer
+	if (!client.getResponseSize())
+		return -1;
 	__D_DISPLAY("data flag from write event: " << event.data);
 	if (event.data < static_cast<long>(client.getLenToSend()))
 	{

--- a/core/server_run_unix.cpp
+++ b/core/server_run_unix.cpp
@@ -51,6 +51,8 @@ static int	run_server(const int kq,
 				if (ret == -1 || ret == 0)
 					remove_client(*client_map, event_fd);
 			}
+			else
+				remove_client(*client_map, event_fd);
 		}
 		//system("leaks webserv.out");
 	}

--- a/utils/file_utilities.cpp
+++ b/utils/file_utilities.cpp
@@ -37,12 +37,15 @@ void	file_to_string(std::string& response,
 				const std::string& filename, int filesize)
 {
 	std::ifstream	ifs(filename);
+	char			*buf;
 
 	if (!ifs.good())
 		return ;
 	response.reserve(response.size() + filesize);
-	response.append(std::istreambuf_iterator<char>(ifs),
-			std::istreambuf_iterator<char>());
+	buf = new char [filesize];
+	ifs.read(buf, filesize);
+	response.append(buf, filesize);
+	delete buf;
 	ifs.close();
 }
 


### PR DESCRIPTION
It was due to the fact that send response was triggered whereas response was empty.
I added a condition to return in that case but it should be temporary & the reason why it is triggered while it shouldn't should be found
Also removed the stream_iterator way to append a string from an input
file bc it is sooo much slower than a classic file to buffer & buffer to
string! (at least x10)